### PR TITLE
Formally opt-in to future breaking change (removeDeprecatedGapUtilities)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
     uniformColorPalette: true,
     extendedSpacingScale: true,
   },
+  future: {
+    removeDeprecatedGapUtilities: true,
+  },
   purge: {
     mode: 'all',
     content: ['src/**/*.js'],


### PR DESCRIPTION
## Changes:

- Formally opt in to future breaking change (removeDeprecatedGapUtilities)

## Context:

Hi @adamwathan! :smile: 

This is the pull request that you wanted after you closed #31.

I've checked, and it turns out you're already using the newer gap utility classes... :facepalm:  :nerd_face: 

Therefore, the only thing this pull request changes is that we now formally opt-in to this future breaking change by setting the correct flag in the `tailwind.config.js` file.

## Reference:

https://tailwindcss.com/docs/upcoming-changes#remove-deprecated-gap-utilities