### PR TITLE
Add title to icon name label

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -749,7 +749,7 @@ function Icon({ icon }) {
           </div>
         </Transition>
       </div>
-      <div className="mt-3 truncate text-center text-[0.8125rem] leading-6 text-slate-500">
+      <div className="mt-3 truncate text-center text-[0.8125rem] leading-6 text-slate-500" title={icon.name}>
         {icon.name}
       </div>
     </div>


### PR DESCRIPTION
If a title is truncated, there's no way to see the full text. Knowing the icon's name is required if you're importing the icon from the (e.g.) the React library. An alternative would also to be including the name (via data attribute?) when copying the SVG/other source.