### PR TITLE
Allow icon search to include dashes

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -928,7 +928,7 @@ function Blur(props) {
 
 function Icons({ icons, query }) {
   let filteredIcons = query
-    ? matchSorter(icons, query, { keys: ['name', 'tags'] })
+    ? matchSorter(icons, query.replace(/\s+/, '-'), { keys: ['name', 'tags'] })
     : icons
 
   if (query && filteredIcons.length === 0) {


### PR DESCRIPTION
Currently, searching an icon containing dashes by its exact name does not yield matches. An example is that the query `user group` does not match icon `user-group`.

Spaces should be treated as dashes so that it can match the exact icon names:

<img width="1406" alt="Treat spaces as dashes" src="https://user-images.githubusercontent.com/10718366/192104130-760cc526-5cc5-4203-816c-016d7dc0428c.png">
