### PR TITLE
Small fix on typo keydown

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1029,7 +1029,7 @@ export default function Home({ version }) {
     window.addEventListener('keydown', onKeyDown)
 
     return () => {
-      window.removeEventListener('keydown', onkeydown)
+      window.removeEventListener('keydown', onKeyDown)
     }
   }, [])
 


### PR DESCRIPTION
Small fix on line 1029, file src/pages/index.js
Typo on word onkeydown
```
    window.addEventListener('keydown', onKeyDown)

    return () => {
      window.removeEventListener('keydown', onkeydown)
    }
```

Now:
```
    window.addEventListener('keydown', onKeyDown)

    return () => {
      window.removeEventListener('keydown', onKeyDown)
    }
```